### PR TITLE
support snake_case file names in graph verification

### DIFF
--- a/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
@@ -140,7 +140,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
      * @returns 
      */
     private resolveNode(importPath: string): cleanNode | null {
-        importPath = importPath.toLowerCase();
+        importPath = importPath.toLowerCase().replace(/_/g, "");
         if (importPath.includes("viewmodel")) return "viewModel"; // must be verified before 'view'
         if (importPath.includes("view")) return "view";
         if (importPath.includes("database")) return "database";
@@ -163,7 +163,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
      * @returns 
      */
     private resolveLayer(importPath: string): cleanLayer | undefined {
-        importPath = importPath.toLowerCase();
+        importPath = importPath.toLowerCase().replace(/_/g, "");
         if (importPath.includes("viewmodel")) return "interfaceAdapters"; // must be verified before 'view'
         if (importPath.includes("view")) return "frameworksAndDrivers";
         if (importPath.includes("database")) return "frameworksAndDrivers";

--- a/clean-architecture-visualizer/tests/backend/use_cases/graphVerification.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/graphVerification.test.ts
@@ -49,6 +49,45 @@ describe("Ensures that resolveLayer correctly identifies layers from their file 
     );
 });
 
+describe("Ensures that resolveLayer correctly identifies layers from their file path, snake_case", () => {
+
+    const genericInteractor = new GraphVerificationInteractor(
+        genericFileAccess,
+        genericNeighbourAccess,
+        genericDBAccess
+    );
+
+    const testCases: [string, string][] = [
+        ["frameworksAndDrivers",    "/src/views/test/test_view.ts"],
+        ["interfaceAdapters",       "/src/views/test/test_view_model.ts"],
+        ["frameworksAndDrivers",    "/src/database/test/test_database.ts"],
+        ["enterpriseBusinessRules", "/src/entity/test/test_entities.ts"],
+        ["applicationBusinessRules","/src/data_access/test/test_access_interface.ts"],
+        ["frameworksAndDrivers",    "/src/data_access/test/test_access.ts"],
+        ["interfaceAdapters",       "/src/interface_adapters/test/test_controller.ts"],
+        ["interfaceAdapters",       "/src/interface_adapters/test/test_presenter.ts"],
+        ["applicationBusinessRules","/src/use_case/test/test_input_boundary.ts"],
+        ["applicationBusinessRules","/src/use_case/test/test_input_data.ts"],
+        ["applicationBusinessRules","/src/use_case/test/test_output_boundary.ts"],
+        ["applicationBusinessRules","/src/use_case/test/test_output_data.ts"],
+        ["applicationBusinessRules","/src/use_case/test/test_interactor.ts"],
+    ];
+
+    it.each(testCases)(
+        "resolves '%s' from path '%s'", (expectedLayer, path) => {
+            const result = (genericInteractor as any).resolveLayer(path);
+            expect(result).toBe(expectedLayer);
+        }
+    );
+
+    it.each(["/src/types/testTypes.ts", "/src/.gitkeep"])(
+        "returns undefined from the path %s", (path) => {
+            const result = (genericInteractor as any).resolveLayer(path);
+            expect(result).toBeUndefined();
+        }
+    );
+});
+
 describe("Ensures that verifyOutNeighbours correctly classifies the number of Clean violations", () => {
 
     function getAllViolations(graphs: useCaseGraph[]): number {


### PR DESCRIPTION
## Summary
- `resolveNode()` and `resolveLayer()` in `graphVerificationInteractor.ts` 
  previously only recognized camelCase file names (e.g. `TransferInputData.java`)
- Snake_case file names (e.g. `transfer_input_data.java`) would fail to match 
  any cleanNode and be silently ignored, producing an empty/incomplete diagram
- Fixed by stripping underscores from the file path before pattern matching, 
  normalizing both conventions to the same format

## Test plan
- [x] Existing camelCase tests still pass
- [x] New snake_case test cases added to `graphVerification.test.ts` for 
      `resolveLayer` covering all 13 cleanNode types
- [x] All 95 tests passing

Closes #138