### PR TITLE
feat: add early exit if use_case files already exist in src

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 Anna Myllyniemi,
+Eric Xu,
 Matthew Dahlgren,
 Vithu Thayalan,
 Vivian Deng

--- a/clean-architecture-visualizer/src/use_case/initProject/initProjectInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/initProject/initProjectInteractor.ts
@@ -18,8 +18,14 @@ export class InitProjectInteractor implements InitProjectInputBoundary{
 
     async execute(): Promise<void> {
         try {
+            
             let currPath = await this.fileAccess.getCurrentPath();
             currPath = path.join(currPath, "src")
+
+            // 0. Check if any use_case files have already been initialized
+            if (await this.fileAccess.bfsFindDir(currPath, 'use_case')) {
+                throw new Error("project already initialized")
+            }
             
             // 1. Define base paths using path.join for cross-platform support
             const javaPath = path.join(currPath, "main", "java");

--- a/clean-architecture-visualizer/tests/backend/use_cases/intiProject.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/intiProject.test.ts
@@ -82,4 +82,17 @@ describe("InitProjectInteractor", () => {
         expect(mockOutputData.setOutputData).toHaveBeenCalledWith(false);
         expect(mockFileAccess.createDirectory).not.toHaveBeenCalled();
     });
+
+    it("should fail if already initialized", async () => {
+        // Arrange
+        mockFileAccess.getCurrentPath.mockResolvedValue(ROOT_PATH)
+        mockFileAccess.bfsFindDir.mockResolvedValue(`${ROOT_PATH}/src/main/java/use_case`)
+        
+        // Act
+        await interactor.execute()
+        
+        // Assert
+        expect(mockOutputData.setOutputData).toHaveBeenCalledWith(false)
+        expect(mockFileAccess.createDirectory).not.toHaveBeenCalled()
+    });
 });


### PR DESCRIPTION
## Summary
- Early exit added to `InitProjectInteractor` to prevent re-initialization of an already initialized project
- Before creating any directories, the interactor checks if a `use_case` directory already exists under `src/`
- If found, sets output to `false` and returns early without creating any files

## Test Plan
- [x] Existing tests still pass, directory creation and success output on first run unaffected
- [x] New test case added: when `bfsFindDir` returns a non-null path for `use_case`, the interactor sets output to `false`, does not call `createDirectory`, and returns early

## Future Suggestion
- Current early exit uses `bfsFindDir` which performs a BFS traversal — O(V+E)
- Since `use_case` is always at a deterministic path (`src/main/java/use_case`) or (`src/test/java/use_case)`, a `directoryExists(path: string):` method on the `FileAccess` interface that directly checks would allow an O(1) check instead