### PR TITLE
chore(tests): expand getProjectSummary test suite

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 Angelina Jiang,
 Anna Myllyniemi,
+Ethan Diep,
 Eric Xu,
 Matthew Dahlgren,
 Seokjin Yoo,

--- a/clean-architecture-visualizer/tests/backend/use_cases/getProjectSummary.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getProjectSummary.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach} from '@jest/globals';
 import { GetProjectSummaryInteractor } from "../../../src/use_case/getProjectSummary/getProjectSummaryInteractor.js";
 import { SessionDBAccess } from "../../../src/data_access/sessionDBAccess.js";
+import { useCaseGraph } from '../../../src/entity/useCaseGraph.js';
 import type { GetProjectSummaryOutputData } from "../../../src/use_case/getProjectSummary/getProjectSummaryOutputData.js";
+import type { SessionData } from '../../../src/types/sessionData.js';
+import type { neighbourMap } from '../../../src/types/neighbourMap.js';
+import type { cleanNode } from '../../../src/types/cleanNode.js';
 
 const genericDBAccess = new SessionDBAccess();
 
@@ -14,15 +18,56 @@ function makeOutputData(): GetProjectSummaryOutputData & { result: any } {
     } as GetProjectSummaryOutputData & { result: any };
 }
 
+// Builds a list of useCaseGraphs with mock violation edges, given a map of use case name to violation count
+function mockUseCaseGraphList(namesToNumViolationEdges: Map<string, number>): useCaseGraph[] {
+    const result = [] as useCaseGraph[];
+
+    for (const [name, numViolationEdges] of namesToNumViolationEdges) {
+        const ucGraph = new useCaseGraph(name);
+        for (let i = 0; i < numViolationEdges; i ++) {
+            // "view" and "controller" are arbitrary cleanNode values and can be modified
+            ucGraph.setViolation(["view", "controller"] as [cleanNode, cleanNode]);
+        }
+        result.push(ucGraph);
+    }
+
+    return result;
+}
+
 describe("GetProjectSummaryInteractor", () => {
 
     beforeEach(() => {
         genericDBAccess.resetDB();
-    })
+    });
+
+    describe("getProjectSummary — Project Name", () => {
+
+        it("correctly handles an empty project name", async () => {
+            genericDBAccess.setProjectName("");
+
+            const outputData = makeOutputData();
+            const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
+            await interactor.getProjectSummary();
+
+            expect(outputData.result.project_name).toBe("");
+        });
+
+        it("does not change the project name from the database", async () => {
+            genericDBAccess.setProjectName("My Project");
+
+            const outputData = makeOutputData();
+            const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
+            await interactor.getProjectSummary();
+
+            expect(outputData.result.project_name).toBe("My Project");
+        });
+
+    });
+
 
     describe("getProjectSummary — Statistics", () => {
         
-        it("returns the correct project name and basic counts", async () => {
+        it("returns the correct properties in the output", async () => {
             const outputData = makeOutputData();
             const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
 
@@ -32,7 +77,82 @@ describe("GetProjectSummaryInteractor", () => {
             expect(outputData.result).toHaveProperty("project_name");
             expect(outputData.result).toHaveProperty("total_use_cases");
             expect(outputData.result).toHaveProperty("total_violations");
+            expect(outputData.result).toHaveProperty("use_cases");
         });
+
+        it("returns a total use case count consistent with the number of use cases", async () => {
+            // Set up a list of mock use cases
+            const mockUseCases: SessionData["useCases"] = [
+                {
+                    id: "uc-1",
+                    name: "Sign in",
+                    outNeighbours: {} as neighbourMap,
+                    fileKeys: [],
+                    violationEdges: [],
+                    missingNodes: []
+                },
+                {
+                    id: "uc-2",
+                    name: "Sign out",
+                    outNeighbours: {} as neighbourMap,
+                    fileKeys: [],
+                    violationEdges: [],
+                    missingNodes: []
+                },
+                {
+                    id: "uc-3",
+                    name: "Create user",
+                    outNeighbours: {} as neighbourMap,
+                    fileKeys: [],
+                    violationEdges: [],
+                    missingNodes: []
+                }
+            ];
+
+            // Inject them into the database
+            for (const uc of mockUseCases) {
+                genericDBAccess.setNumUseCases(genericDBAccess.getNumUseCases() + 1);
+                genericDBAccess.upsertUseCase(uc);
+            }
+
+            const outputData = makeOutputData();
+            const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
+            await interactor.getProjectSummary();
+            
+            const numUseCases = mockUseCases.length;
+            expect(outputData.result.use_cases.length).toBe(numUseCases);
+            expect(outputData.result.total_use_cases).toBe(numUseCases);
+        });
+
+        it("returns a total violations count consistent with the sum of all use case violations", async () => {
+            // set up a map of mock use names to the corresponding number of violations for the test
+            const mockUseCaseMap = new Map<string, number>([
+                ["Sign in", 3],
+                ["Sign out", 0],
+                ["Create user", 1],
+            ])
+            const mockUseCases: useCaseGraph[] = mockUseCaseGraphList(mockUseCaseMap);
+
+            // compute violation count from the useCaseGraph list
+            let violationCount = 0;
+
+            mockUseCases.forEach(useCase => {
+                violationCount += useCase.getViolationCount();
+            });
+
+            genericDBAccess.setNumViolations(violationCount);
+
+            const outputData = makeOutputData();
+            const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
+            await interactor.getProjectSummary();
+
+            // compute violation count from the useCaseGraph map 
+            const totalViolations = [...mockUseCaseMap.values()].reduce((accumulator, numViolations) => accumulator + numViolations, 0);
+
+            expect(outputData.result.total_violations).toBe(totalViolations);
+            
+        });
+
     });
 
     describe("getProjectSummary — Use Case Formatting", () => {
@@ -64,9 +184,6 @@ describe("GetProjectSummaryInteractor", () => {
         });
 
         it("returns an empty array for use_cases if none exist in DB", async () => {
-            // Ensure DB is empty for this test
-            (genericDBAccess as any).clearAllUseCases?.(); 
-
             const outputData = makeOutputData();
             const interactor = new GetProjectSummaryInteractor(genericDBAccess, outputData);
 


### PR DESCRIPTION
## Overview
Adds new tests for the `getProjectSummary` use case and fixes the broken npm test script in `clean-architecture-visualizer/package.json`

## Proposed Changes

- New tests added
    1. an empty `project_name` (`""`) does not get modified after `getProjectSummary` is called
    2. a non-empty `project_name` does not get modified after `getProjectSummary` is called
    3. `total_use_cases` is equivalent to the number of `use_cases` detected
    4. `total_violations` is equivalent to the sum of the `violation_count` of each use case
- Modified tests
    - under `getProjectSummary — Statistics`, rename `returns the correct project name and basic counts` to `returns the correct properties in the output`
    - add a check for the existence of the `use_cases` field in the output (same test as above) 
    - under `getProjectSummary — Use Case Formatting` -> `returns an empty array for use_cases if none exist in DB`, remove redundant code that ensures database is empty, as this is already done in `beforeEach`
- Fix npm test script in `clean-architecture-visualizer/package.json`

**Note**: Tests iii. and iv. currently fail. This is perhaps because of the way the upsert functions for use cases and violations is implemented: when the db functions `getNumUseCases` or `getNumViolations` are called, they seem to retrieve old data (pre-upsertion) rather than the new data.

**Next steps**:
- confirm incorrect behavior of upsert functions and fix them
- look into whether this behavior also appears in the set functions
- write additional tests using set functions instead of upsert

## How to Test & Review

- In `clean-architecture-visualizer`, run `npm test`. The test suites should all run and there should be no terminal errors.
- In `clean-architecture-visualizer`, run `npm test -- getProjectSummary.test.ts`. The test results should be: 2 failed, 5 passed, 7 total.

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |     X     |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |     X     |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer, and a fellow student.

## Questions and Comments

CI Jest tests should fail for tests iii. and iv. consistent with description in proposed changes.

Based on note above about tests iii. and iv. failing, are the upsert functions incorrectly implemented or are the get functions incorrectly implemented? If the upsert functions are incorrectly implemented, are the set functions also implemented in this way?