### PR TITLE
feat(use-case): early stop create usecase if usecase already exists

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 Anna Myllyniemi,
 Matthew Dahlgren,
+Seokjin Yoo
 Vithu Thayalan,
 Vivian Deng

--- a/clean-architecture-visualizer/src/app/appBuilder.ts
+++ b/clean-architecture-visualizer/src/app/appBuilder.ts
@@ -183,6 +183,6 @@ export class AppBuilder {
     runCreateUseCase(name: string) {
         this.createUseCaseInteractor?.newUseCase(name);
         this.createUseCaseController?.execute();
-        console.log(chalk.green("Usecase " + name + " has been created."));
+        console.log(chalk.green(`Usecase ${name} has been created.`));
     }
 }

--- a/clean-architecture-visualizer/src/data_access/fileAccess.ts
+++ b/clean-architecture-visualizer/src/data_access/fileAccess.ts
@@ -1,10 +1,9 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from "fs/promises";
+import path from "path";
 
 import type { FileAccessInterface } from "./fileAccessInterface.js";
 
 export class FileAccess implements FileAccessInterface {
-
     /**
      * Find the use case folder and collect the name of each use case.
      * @returns A list of the names of each use case.
@@ -21,7 +20,7 @@ export class FileAccess implements FileAccessInterface {
             withFileTypes: true,
         });
 
-        return useCases.filter(e => e.isDirectory()).map(e => e.name);
+        return useCases.filter((e) => e.isDirectory()).map((e) => e.name);
     }
 
     /**
@@ -79,7 +78,7 @@ export class FileAccess implements FileAccessInterface {
 
         while (queue.length > 0) {
             const currentPath = queue.shift()!;
-            
+
             if (visited.has(currentPath)) continue;
             visited.add(currentPath);
 
@@ -107,10 +106,7 @@ export class FileAccess implements FileAccessInterface {
      * @param target the name of the target directory (ending location).
      * @returns A list of the directories found within the target directory.
      */
-    async findDirectory(
-    curr: string,
-    target: string
-    ): Promise<string | null> {
+    async findDirectory(curr: string, target: string): Promise<string | null> {
         const entries = await fs.readdir(curr, { withFileTypes: true });
 
         for (const entry of entries) {
@@ -139,17 +135,16 @@ export class FileAccess implements FileAccessInterface {
         let result: string[] = [];
 
         try {
-            const fileContent: string = await fs.readFile(filePath, { encoding: 'utf-8' });
+            const fileContent: string = await fs.readFile(filePath, { encoding: "utf-8" });
             const fileLines = fileContent.split("\n");
-            fileLines.forEach(line => {
+            fileLines.forEach((line) => {
                 if (line.startsWith("import ")) {
                     line = line.trim();
                     const lastSpace = line.lastIndexOf(" ");
                     result.push(line.substring(lastSpace + 1));
                 }
             });
-        }
-        catch {
+        } catch {
             console.log("The file: " + filePath + " could not be found");
             return [];
         }
@@ -158,8 +153,8 @@ export class FileAccess implements FileAccessInterface {
     }
 
     /**
-     * Get the project name, this is either the directory BEFORE "src", or if the 
-     * process is running in a directory ABOVE "src" we assume that we are in the 
+     * Get the project name, this is either the directory BEFORE "src", or if the
+     * process is running in a directory ABOVE "src" we assume that we are in the
      * project directory.
      * @returns a string representing the project name.
      */
@@ -174,15 +169,13 @@ export class FileAccess implements FileAccessInterface {
     /**
      * Get the file content of path as a single string.
      * @param filePath is a path to a valid file
-     * @returns 
+     * @returns
      */
     async getFileContent(filePath: string): Promise<string> {
-        
         try {
-            const fileContent: string = await fs.readFile(filePath, { encoding: 'utf-8' });
+            const fileContent: string = await fs.readFile(filePath, { encoding: "utf-8" });
             return fileContent;
-        }
-        catch {
+        } catch {
             console.log("The file: " + filePath + " could not be found");
             return "";
         }
@@ -198,22 +191,20 @@ export class FileAccess implements FileAccessInterface {
     async getFileSnippet(filePath: string, target: string): Promise<string | undefined> {
         const content = await this.getFileContent(filePath);
         if (!content) return undefined;
- 
+
         const lines = content.split("\n");
-        const importLines = lines.filter(line => line.trimStart().startsWith("import "));
- 
+        const importLines = lines.filter((line) => line.trimStart().startsWith("import "));
+
         if (!target) {
             // No target specified — return all import lines joined
             return importLines.length > 0 ? importLines.join("\n") : undefined;
         }
- 
-        const match = importLines.find(line =>
-            line.toLowerCase().includes(target.toLowerCase())
-        );
- 
+
+        const match = importLines.find((line) => line.toLowerCase().includes(target.toLowerCase()));
+
         return match?.trim() ?? undefined;
     }
- 
+
     /**
      * Find the 1-based line number of the first import line in a file that
      * references the given target name.
@@ -224,17 +215,30 @@ export class FileAccess implements FileAccessInterface {
     async getLineNumber(filePath: string, target: string): Promise<number | undefined> {
         const content = await this.getFileContent(filePath);
         if (!content) return undefined;
- 
+
         const lines = content.split("\n");
- 
+
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
             if (line.trimStart().startsWith("import ") && line.toLowerCase().includes(target.toLowerCase())) {
                 return i + 1; // 1-based line number
             }
         }
- 
+
         return undefined;
+    }
+
+    /**
+     * Check whether a file/directory at path exists or not.
+     * @param path the path of the file to be checked
+     */
+    async exists(path: string): Promise<boolean> {
+        try {
+            await fs.access(path);
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     /**

--- a/clean-architecture-visualizer/src/data_access/fileAccessInterface.ts
+++ b/clean-architecture-visualizer/src/data_access/fileAccessInterface.ts
@@ -9,5 +9,6 @@ export interface FileAccessInterface {
     createDirectory(filePath: string): Promise<void>;
     getCurrentPath(): Promise<string>;
     bfsFindDir(curr: string, target: string): Promise<string | null>;
+    exists(path: string): Promise<boolean>;
     createFile(filePath: string, content?: string): Promise<void>;
 }

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInteractor.ts
@@ -3,9 +3,9 @@ import type { CreateUseCaseInputBoundary } from "./createUseCaseInputBoundary.js
 import { CreateUseCaseInputData } from "./createUseCaseInputData.js";
 import { CreateUseCaseOutputData } from "./createUseCaseOutputData.js";
 import path from "path";
+import chalk from "chalk";
 
 export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
-    
     private readonly fileAccess: FileAccessInterface;
     private inputData: CreateUseCaseInputData;
     private readonly outputData: CreateUseCaseOutputData;
@@ -22,20 +22,28 @@ export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
 
     async execute(): Promise<void> {
         try {
-            const useCaseName = this.inputData.getUseCaseName().split(" ").join('');
+            const useCaseName = this.inputData.getUseCaseName().split(" ").join("");
             const currPath = await this.fileAccess.getCurrentPath();
 
             // Find base directories
-            let useCaseDir = await this.fileAccess.bfsFindDir(currPath, "use_case");
-            let interfaceAdapterDir = await this.fileAccess.bfsFindDir(currPath, "interface_adapter");
+            const useCaseDir = await this.fileAccess.bfsFindDir(currPath, "use_case");
+            const interfaceAdapterDir = await this.fileAccess.bfsFindDir(currPath, "interface_adapter");
 
             if (!useCaseDir || !interfaceAdapterDir) {
-                throw new Error("Could not find use_case or interface_adapter, try initiating project first");
+                throw new Error("Could not find use_case or interface_adapter, try initiating project first.");
             }
 
             const targetUseCasePath = path.join(useCaseDir, useCaseName);
             const targetInterfacePath = path.join(interfaceAdapterDir, useCaseName);
 
+            // Check if files already exist
+            const useCaseExists = await this.fileAccess.exists(targetUseCasePath);
+            const interfaceExists = await this.fileAccess.exists(targetInterfacePath);
+            if (useCaseExists || interfaceExists) {
+                throw new Error(`Usecase ${useCaseName} already exists.`);
+            }
+
+            // Create use case
             await this.fileAccess.createDirectory(targetUseCasePath);
             await this.fileAccess.createDirectory(targetInterfacePath);
 
@@ -57,9 +65,10 @@ export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
             await createJavaFile(targetInterfacePath, "Presenter");
 
             this.outputData.setOutputData(true);
-
         } catch (error) {
-            console.error(error);
+            if (error instanceof Error) {
+                console.log(chalk.red(error.message));
+            }
             this.outputData.setOutputData(false);
         }
     }

--- a/clean-architecture-visualizer/tests/backend/use_cases/createUseCase.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/createUseCase.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { CreateUseCaseinteractor } from "../../../src/use_case/createUseCase/createUseCaseInteractor.js";
 import type { FileAccessInterface } from "../../../src/data_access/fileAccessInterface.js";
 import type { CreateUseCaseInputData } from "../../../src/use_case/createUseCase/createUseCaseInputData.js";
@@ -15,6 +15,7 @@ describe("CreateUseCaseInteractor", () => {
         mockFileAccess = {
             getCurrentPath: jest.fn<any>(),
             bfsFindDir: jest.fn<any>(),
+            exists: jest.fn<any>(),
             createDirectory: jest.fn<any>(),
             createFile: jest.fn<any>(),
         } as any;
@@ -42,7 +43,7 @@ describe("CreateUseCaseInteractor", () => {
         // Assert
         // Check if name was cleaned (spaces removed)
         const expectedName = "LoginUser";
-        
+
         // Verify directory creation
         expect(mockFileAccess.createDirectory).toHaveBeenCalledWith("/root/src/use_case/LoginUser");
         expect(mockFileAccess.createDirectory).toHaveBeenCalledWith("/root/src/interface_adapter/LoginUser");
@@ -50,7 +51,7 @@ describe("CreateUseCaseInteractor", () => {
         // Verify key files were created
         expect(mockFileAccess.createFile).toHaveBeenCalledWith(expect.stringContaining("LoginUserInputBoundary.java"));
         expect(mockFileAccess.createFile).toHaveBeenCalledWith(expect.stringContaining("LoginUserController.java"));
-        
+
         // Verify success signal
         expect(mockOutputData.setOutputData).toHaveBeenCalledWith(true);
     });
@@ -85,3 +86,4 @@ describe("CreateUseCaseInteractor", () => {
         expect(mockOutputData.setOutputData).toHaveBeenCalledWith(false);
     });
 });
+


### PR DESCRIPTION
## Overview

This PR adds an early exit mechanism to the command `cave usecase <usecase>`. Currently, then `cave usecase <usecase>` is called on an already-existing usecase, the command correctly fails but only because overwriting an already existing file was not allowed in the code.

## Proposed Changes

This addresses #136.

The change involves a new method in `fileAccess.ts` named `exists` which checks whether a given file/directory exists or not.
Then `createUseCaseInteractor.ts`'s `execute` method has been modified slightly with an extra if statement checking whether directories 
- `src/main/java/use_case/<use-case>, or 
- `src/main/java/interface_adapter/<use-case> 

exists.

Please note that there are more changes recorded in the commit than the actual change in logic, due to inconsistencies in formatting.

## How to Test & Review

To verify the changes, go in a project and run
```bash
cave usecase <usecase>
```
twice, where `<usecase>` is some unique usecase that has not been created yet in the project.

The first run should succeed (with the message `Usecase example has been created.`) and the second run should fail with the following message:
```bash
Usecase example has been created.
Usecase example already exists.
```

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |  X        |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
    - This is **required** for new features.

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer, and a fellow student.
- [ ] Technical Debt: If temporary workarounds or "TODOs" were used, I have opened a tracking issue to address them properly.
    - Linked Issues: 

## Questions and Comments

Improvements to current implementation might involve more fine-grained detection system, where specific missing files can be detected and created accordingly.