### PR TITLE
refactor(createUseCase): stricter adherence to clean architecture

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 Anna Myllyniemi,
 Eric Xu,
 Matthew Dahlgren,
-Seokjin Yoo
+Seokjin Yoo,
 Vithu Thayalan,
 Vivian Deng

--- a/clean-architecture-visualizer/src/app/appBuilder.ts
+++ b/clean-architecture-visualizer/src/app/appBuilder.ts
@@ -13,9 +13,9 @@ import type { InitProjectInputBoundary } from "../use_case/initProject/initProje
 import type { InitProjectContoller } from "../interface_adapter/intiProject/initProjectContoller.js";
 import type { CreateUseCaseInputBoundary } from "../use_case/createUseCase/createUseCaseInputBoundary.js";
 import type { CreateUseCaseController } from "../interface_adapter/createUseCase/createUseCaseController.js";
-import { CreateUseCaseInputData } from "../use_case/createUseCase/createUseCaseInputData.js";
-import { CreateUseCaseOutputData } from "../use_case/createUseCase/createUseCaseOutputData.js";
 import { InitProjectOutputData } from "../use_case/initProject/initProjectOutputData.js";
+import { CreateUseCaseInteractor } from "../use_case/createUseCase/createUseCaseInteractor.js";
+import { CreateUseCasePresenter } from "../interface_adapter/createUseCase/createUseCasePresenter.js";
 
 export class AppBuilder {
     private fileAccess?: FileAccess;
@@ -70,17 +70,12 @@ export class AppBuilder {
         return this;
     }
 
-    buildCreateUseCaseInteractor(
-        InteractorClass: new (
-            fileAccess: FileAccess,
-            inputData?: CreateUseCaseInputData,
-            outputData?: CreateUseCaseOutputData
-        ) => CreateUseCaseInputBoundary
-    ): this {
+    buildCreateUseCaseInteractor(): this {
         if (!this.fileAccess) {
             throw new Error("FileAccess must be set before building CreateUseCaseInteractor");
         }
-        this.createUseCaseInteractor = new InteractorClass(this.fileAccess);
+        const createUseCasePresenter = new CreateUseCasePresenter();
+        this.createUseCaseInteractor = new CreateUseCaseInteractor(this.fileAccess, createUseCasePresenter);
         return this;
     }
 
@@ -130,10 +125,7 @@ export class AppBuilder {
         if (!this.createUseCaseInteractor) {
             throw new Error("CreateUseCaseInteractor must be built before controller");
         }
-        
-        this.createUseCaseController = new ControllerClass(
-            this.createUseCaseInteractor
-            );
+        this.createUseCaseController = new ControllerClass(this.createUseCaseInteractor);
         return this;
     }
 
@@ -181,8 +173,6 @@ export class AppBuilder {
     }
 
     runCreateUseCase(name: string) {
-        this.createUseCaseInteractor?.newUseCase(name);
-        this.createUseCaseController?.execute();
-        console.log(chalk.green(`Usecase ${name} has been created.`));
+        this.createUseCaseController?.execute(name);
     }
 }

--- a/clean-architecture-visualizer/src/app/index.ts
+++ b/clean-architecture-visualizer/src/app/index.ts
@@ -22,7 +22,7 @@ import { SessionDBAccess } from "../data_access/sessionDBAccess.js";
 import { GraphVerificationController } from '../interface_adapter/graphVerification/graphVerificationController.js';
 import { GraphVerificationInteractor } from '../use_case/graphVerification/graphVerificationInteractor.js';
 import { startServer } from "../server/server.js";
-import { CreateUseCaseinteractor } from "../use_case/createUseCase/createUseCaseInteractor.js";
+import { CreateUseCaseInteractor } from "../use_case/createUseCase/createUseCaseInteractor.js";
 import { InitProjectInteractor } from "../use_case/initProject/initProjectInteractor.js";
 import { CreateUseCaseController } from "../interface_adapter/createUseCase/createUseCaseController.js";
 import { InitProjectContoller } from "../interface_adapter/intiProject/initProjectContoller.js";
@@ -36,7 +36,7 @@ const app = new AppBuilder()
   .withCleanArchAccess(new CleanArchAccess())
   .withSessionDBAccess(new SessionDBAccess())
   .buildGraphVerificationInteractor(GraphVerificationInteractor)
-  .buildCreateUseCaseInteractor(CreateUseCaseinteractor)
+  .buildCreateUseCaseInteractor()
   .buildInitProjectInteractor(InitProjectInteractor)
   .buildGraphVerificationController(GraphVerificationController)
   .buildCreateUseCaseController(CreateUseCaseController)

--- a/clean-architecture-visualizer/src/interface_adapter/createUseCase/createUseCaseController.ts
+++ b/clean-architecture-visualizer/src/interface_adapter/createUseCase/createUseCaseController.ts
@@ -1,11 +1,11 @@
 import type { CreateUseCaseInputBoundary } from "../../use_case/createUseCase/createUseCaseInputBoundary.js";
+import { CreateUseCaseInputData } from "../../use_case/createUseCase/createUseCaseInputData.js";
 
 export class CreateUseCaseController {
-    constructor(
-            private readonly inputBoundary: CreateUseCaseInputBoundary
-        ) {}
-    
-    async execute(): Promise<void> {
-        await this.inputBoundary.execute();
+    constructor(private readonly inputBoundary: CreateUseCaseInputBoundary) {}
+
+    async execute(useCase: string): Promise<void> {
+        const createUseCaseInputData = new CreateUseCaseInputData(useCase);
+        await this.inputBoundary.execute(createUseCaseInputData);
     }
 }

--- a/clean-architecture-visualizer/src/interface_adapter/createUseCase/createUseCasePresenter.ts
+++ b/clean-architecture-visualizer/src/interface_adapter/createUseCase/createUseCasePresenter.ts
@@ -1,10 +1,20 @@
+import chalk from "chalk";
 import type { CreateUseCaseOutputBoundary } from "../../use_case/createUseCase/createUseCaseOutputBoundary.js";
 import type { CreateUseCaseOutputData } from "../../use_case/createUseCase/createUseCaseOutputData.js";
 
 export class CreateUseCasePresenter implements CreateUseCaseOutputBoundary {
-    
-    constructor(private readonly outputData: CreateUseCaseOutputData) {}
-    getOutputData(): boolean {
-        return this.outputData.getOutputData();
-    } 
+    private error: string | null = null;
+
+    showSuccessView(createUseCaseOutputData: CreateUseCaseOutputData) {
+        console.log(chalk.green(`Usecase ${createUseCaseOutputData.getUseCase()} has been created.`));
+    }
+
+    showFailView(error: string) {
+        console.log(chalk.red(error));
+        this.error = error;
+    }
+
+    getError(): string | null {
+        return this.error;
+    }
 }

--- a/clean-architecture-visualizer/src/server/routes/template.ts
+++ b/clean-architecture-visualizer/src/server/routes/template.ts
@@ -4,9 +4,7 @@ import { InitProjectOutputData } from "../../use_case/initProject/initProjectOut
 import { InitProjectInteractor } from "../../use_case/initProject/initProjectInteractor.js";
 import { InitProjectContoller } from "../../interface_adapter/intiProject/initProjectContoller.js";
 import { InitProjectPresetner } from "../../interface_adapter/intiProject/initProjectPresenter.js";
-import { CreateUseCaseInputData } from "../../use_case/createUseCase/createUseCaseInputData.js";
-import { CreateUseCaseOutputData } from "../../use_case/createUseCase/createUseCaseOutputData.js";
-import { CreateUseCaseinteractor } from "../../use_case/createUseCase/createUseCaseInteractor.js";
+import { CreateUseCaseInteractor } from "../../use_case/createUseCase/createUseCaseInteractor.js";
 import { CreateUseCaseController } from "../../interface_adapter/createUseCase/createUseCaseController.js";
 import { CreateUseCasePresenter } from "../../interface_adapter/createUseCase/createUseCasePresenter.js";
 
@@ -14,7 +12,7 @@ const router = Router();
 
 const fileAccess = new FileAccess();
 
-router.post("/template/generate",  async(_req, res) => {
+router.post("/template/generate", async (_req, res) => {
     const outputData = new InitProjectOutputData();
     const interactor = new InitProjectInteractor(fileAccess, outputData);
     const controller = new InitProjectContoller(interactor);
@@ -32,20 +30,18 @@ router.post("/template/generate",  async(_req, res) => {
 });
 
 router.post("/template/add/:useCaseName", async (req, res) => {
-    const inputData = new CreateUseCaseInputData(req.params.useCaseName);
-    const outputData = new CreateUseCaseOutputData();
-    const interactor = new CreateUseCaseinteractor(fileAccess, inputData, outputData);
+    const presenter = new CreateUseCasePresenter();
+    const interactor = new CreateUseCaseInteractor(fileAccess, presenter);
     const controller = new CreateUseCaseController(interactor);
-    const presenter = new CreateUseCasePresenter(outputData);
 
-    await controller.execute();
-    const result = presenter.getOutputData();
- 
+    await controller.execute(req.params.useCaseName);
+    const result = presenter.getError();
+
     if (!result) {
         res.status(404).json({ error: `Could not make use case '${req.params.useCaseName}'` });
         return;
     }
- 
+
     res.status(201).json({ message: `Use case '${req.params.useCaseName}' created successfully` });
 });
 

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInputBoundary.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInputBoundary.ts
@@ -1,4 +1,5 @@
+import type { CreateUseCaseInputData } from "./createUseCaseInputData.js";
+
 export interface CreateUseCaseInputBoundary {
-    execute(): Promise<void>;
-    newUseCase(inputData: string): void;
+    execute(createUseCaseInputData: CreateUseCaseInputData): Promise<void>;
 }

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInputData.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInputData.ts
@@ -1,8 +1,5 @@
 export class CreateUseCaseInputData {
-
-    constructor(
-        private readonly useCase: string
-    ) {}
+    constructor(private readonly useCase: string) {}
 
     getUseCaseName(): string {
         return this.useCase;

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseInteractor.ts
@@ -1,28 +1,19 @@
+import path from "node:path";
 import type { FileAccessInterface } from "../../data_access/fileAccessInterface.js";
 import type { CreateUseCaseInputBoundary } from "./createUseCaseInputBoundary.js";
-import { CreateUseCaseInputData } from "./createUseCaseInputData.js";
+import type { CreateUseCaseInputData } from "./createUseCaseInputData.js";
+import type { CreateUseCaseOutputBoundary } from "./createUseCaseOutputBoundary.js";
 import { CreateUseCaseOutputData } from "./createUseCaseOutputData.js";
-import path from "path";
-import chalk from "chalk";
 
-export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
-    private readonly fileAccess: FileAccessInterface;
-    private inputData: CreateUseCaseInputData;
-    private readonly outputData: CreateUseCaseOutputData;
-
+export class CreateUseCaseInteractor implements CreateUseCaseInputBoundary {
     constructor(
-        fileAccess: FileAccessInterface,
-        inputData: CreateUseCaseInputData = new CreateUseCaseInputData(""),
-        outputData: CreateUseCaseOutputData = new CreateUseCaseOutputData(),
-    ) {
-        this.fileAccess = fileAccess;
-        this.inputData = inputData;
-        this.outputData = outputData;
-    }
+        private readonly fileAccess: FileAccessInterface,
+        private readonly presenter: CreateUseCaseOutputBoundary,
+    ) {}
 
-    async execute(): Promise<void> {
+    async execute(createUseCaseInputData: CreateUseCaseInputData): Promise<void> {
         try {
-            const useCaseName = this.inputData.getUseCaseName().split(" ").join("");
+            const useCaseName = createUseCaseInputData.getUseCaseName().split(" ").join("");
             const currPath = await this.fileAccess.getCurrentPath();
 
             // Find base directories
@@ -30,7 +21,10 @@ export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
             const interfaceAdapterDir = await this.fileAccess.bfsFindDir(currPath, "interface_adapter");
 
             if (!useCaseDir || !interfaceAdapterDir) {
-                throw new Error("Could not find use_case or interface_adapter, try initiating project first.");
+                this.presenter.showFailView(
+                    "Could not find use_case or interface_adapter, try initiating project first.",
+                );
+                return;
             }
 
             const targetUseCasePath = path.join(useCaseDir, useCaseName);
@@ -40,7 +34,8 @@ export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
             const useCaseExists = await this.fileAccess.exists(targetUseCasePath);
             const interfaceExists = await this.fileAccess.exists(targetInterfacePath);
             if (useCaseExists || interfaceExists) {
-                throw new Error(`Usecase ${useCaseName} already exists.`);
+                this.presenter.showFailView(`Usecase ${useCaseName} already exists.`);
+                return;
             }
 
             // Create use case
@@ -64,16 +59,12 @@ export class CreateUseCaseinteractor implements CreateUseCaseInputBoundary {
             await createJavaFile(targetInterfacePath, "Controller");
             await createJavaFile(targetInterfacePath, "Presenter");
 
-            this.outputData.setOutputData(true);
+            const createUseCaseOutputData = new CreateUseCaseOutputData(useCaseName);
+            this.presenter.showSuccessView(createUseCaseOutputData);
         } catch (error) {
             if (error instanceof Error) {
-                console.log(chalk.red(error.message));
+                this.presenter.showFailView(error.message);
             }
-            this.outputData.setOutputData(false);
         }
-    }
-
-    newUseCase(inputData: string): void {
-        this.inputData = new CreateUseCaseInputData(inputData);
     }
 }

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseOutputBoundary.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseOutputBoundary.ts
@@ -1,3 +1,6 @@
+import type { CreateUseCaseOutputData } from "./createUseCaseOutputData.js";
+
 export interface CreateUseCaseOutputBoundary {
-    getOutputData(): boolean;
+    showSuccessView(createUseCaseOutputData: CreateUseCaseOutputData): void;
+    showFailView(error: string): void;
 }

--- a/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseOutputData.ts
+++ b/clean-architecture-visualizer/src/use_case/createUseCase/createUseCaseOutputData.ts
@@ -1,13 +1,7 @@
 export class CreateUseCaseOutputData {
+    constructor(private readonly useCase: string) {}
 
-    private apiOutputData?: boolean;
-
-    setOutputData(outputData: boolean) {
-        this.apiOutputData = outputData;
-    }
-    
-    getOutputData(): boolean {
-        if (this.apiOutputData) return this.apiOutputData;
-        return false;
+    getUseCase(): string {
+        return this.useCase;
     }
 }

--- a/clean-architecture-visualizer/tests/backend/use_cases/createUseCase.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/createUseCase.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { CreateUseCaseinteractor } from "../../../src/use_case/createUseCase/createUseCaseInteractor.js";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { FileAccessInterface } from "../../../src/data_access/fileAccessInterface.js";
-import type { CreateUseCaseInputData } from "../../../src/use_case/createUseCase/createUseCaseInputData.js";
-import type { CreateUseCaseOutputData } from "../../../src/use_case/createUseCase/createUseCaseOutputData.js";
+import { CreateUseCaseInputData } from "../../../src/use_case/createUseCase/createUseCaseInputData.js";
+import { CreateUseCaseOutputData } from "../../../src/use_case/createUseCase/createUseCaseOutputData.js";
+import { CreateUseCaseInteractor } from "../../../src/use_case/createUseCase/createUseCaseInteractor.js";
+import type { CreateUseCaseOutputBoundary } from "../../../src/use_case/createUseCase/createUseCaseOutputBoundary.js";
 
 describe("CreateUseCaseInteractor", () => {
     let mockFileAccess: jest.Mocked<FileAccessInterface>;
-    let mockInputData: jest.Mocked<CreateUseCaseInputData>;
-    let mockOutputData: jest.Mocked<CreateUseCaseOutputData>;
-    let interactor: CreateUseCaseinteractor;
+    let mockPresenter: jest.Mocked<CreateUseCaseOutputBoundary>;
+    let interactor: CreateUseCaseInteractor;
 
     beforeEach(() => {
         // Setup Mocks
@@ -20,30 +20,26 @@ describe("CreateUseCaseInteractor", () => {
             createFile: jest.fn<any>(),
         } as any;
 
-        mockInputData = {
-            getUseCaseName: jest.fn<any>(),
+        mockPresenter = {
+            showSuccessView: jest.fn<any>(),
+            showFailView: jest.fn<any>(),
         } as any;
 
-        mockOutputData = {
-            setOutputData: jest.fn<any>(),
-        } as any;
-
-        interactor = new CreateUseCaseinteractor(mockFileAccess, mockInputData, mockOutputData);
+        interactor = new CreateUseCaseInteractor(mockFileAccess, mockPresenter);
     });
+
+    // TODO: Add a separate test case checking if use case names with spaces wer properly sanitized
 
     it("successfully creates directories and files for a valid use case name", async () => {
         // Arrange
-        mockInputData.getUseCaseName.mockReturnValue("Login User");
         mockFileAccess.getCurrentPath.mockResolvedValue("/root");
         mockFileAccess.bfsFindDir.mockImplementation(async (path, dirName) => `/root/src/${dirName}`);
 
         // Act
-        await interactor.execute();
+        const inputData = new CreateUseCaseInputData("LoginUser");
+        await interactor.execute(inputData);
 
         // Assert
-        // Check if name was cleaned (spaces removed)
-        const expectedName = "LoginUser";
-
         // Verify directory creation
         expect(mockFileAccess.createDirectory).toHaveBeenCalledWith("/root/src/use_case/LoginUser");
         expect(mockFileAccess.createDirectory).toHaveBeenCalledWith("/root/src/interface_adapter/LoginUser");
@@ -53,37 +49,57 @@ describe("CreateUseCaseInteractor", () => {
         expect(mockFileAccess.createFile).toHaveBeenCalledWith(expect.stringContaining("LoginUserController.java"));
 
         // Verify success signal
-        expect(mockOutputData.setOutputData).toHaveBeenCalledWith(true);
+        expect(mockPresenter.showSuccessView).toHaveBeenCalledWith(new CreateUseCaseOutputData("LoginUser"));
+        expect(mockPresenter.showFailView).not.toHaveBeenCalled();
     });
 
     it("fails and sets output data to false if directories are not found", async () => {
         // Arrange
-        mockInputData.getUseCaseName.mockReturnValue("Test");
         mockFileAccess.getCurrentPath.mockResolvedValue("/root");
         // Simulate missing directory
         mockFileAccess.bfsFindDir.mockResolvedValue(null);
 
         // Act
-        await interactor.execute();
+        await interactor.execute(new CreateUseCaseInputData("Test"));
 
         // Assert
-        expect(mockOutputData.setOutputData).toHaveBeenCalledWith(false);
+        expect(mockPresenter.showSuccessView).not.toHaveBeenCalled();
+        expect(mockPresenter.showFailView).toHaveBeenCalledWith(
+            "Could not find use_case or interface_adapter, try initiating project first.",
+        );
         // Ensure no files were attempted to be created
         expect(mockFileAccess.createFile).not.toHaveBeenCalled();
     });
 
+    it("fails and sets output data to false if directories are already present", async () => {
+        // Arrange
+        mockFileAccess.getCurrentPath.mockResolvedValue("/root");
+        mockFileAccess.bfsFindDir.mockImplementation(async (path, dirName) => `/root/src/${dirName}`);
+        // Simulate already existing directory
+        mockFileAccess.exists.mockResolvedValue(true);
+
+        // Act
+        await interactor.execute(new CreateUseCaseInputData("Test"));
+
+        // Assert
+        expect(mockPresenter.showSuccessView).not.toHaveBeenCalled();
+        expect(mockPresenter.showFailView).toHaveBeenCalledWith("Usecase Test already exists.");
+        // Ensure no files or directories were attempted to be created
+        expect(mockFileAccess.createFile).not.toHaveBeenCalled();
+        expect(mockFileAccess.createDirectory).not.toHaveBeenCalled();
+    });
+
     it("fails if an unexpected error occurs during file creation", async () => {
         // Arrange
-        mockInputData.getUseCaseName.mockReturnValue("Test");
         mockFileAccess.getCurrentPath.mockResolvedValue("/root");
         mockFileAccess.bfsFindDir.mockResolvedValue("/root/dir");
         mockFileAccess.createFile.mockRejectedValue(new Error("Disk Full"));
 
         // Act
-        await interactor.execute();
+        await interactor.execute(new CreateUseCaseInputData("Test"));
 
         // Assert
-        expect(mockOutputData.setOutputData).toHaveBeenCalledWith(false);
+        expect(mockPresenter.showSuccessView).not.toHaveBeenCalled();
+        expect(mockPresenter.showFailView).toHaveBeenCalled();
     });
 });
-


### PR DESCRIPTION
## Overview

This PR alters how cave's `createUseCase` usecase was handled for a stricter adherence to clean architecture principles while fixing incorrect output demonstrated in #145 as a bonus. 

## Proposed Changes

There has been modifications to almost every part involved in typical execution of a usecase in projects following clean architecture. As discussed previously the new approach, I make use of the Presenter while making sure interaction with Interactor is only done through the Controller.

- `CreateUseCasePresenter` is now (almost, see below for details) stateless with `showSuccessView` and `showFailView` as the sole output mechanism
- `CreateUseCaseInteractor` communicates results exclusively through the Presenter, never returning data directly
- `CreateUseCaseController` is now in change of InputData construction
- AppBuilder and `index.ts` updated accordingly to reflect the new construction responsibilities
- Tests now mock `CreateUseCaseOutputBoundary` instead of OutputData, asserting on presenter method calls


## How to Test & Review

To verify that the changes made still maintains correct functionality, go in a project and run
```bash
cave usecase <usecase>
```
twice, where `<usecase>` is some unique usecase that has not been created yet in the project.

The first run should succeed (with the message `Usecase <usecase> has been created.`) and the second run should fail with the following message:
```bash
Usecase <usecase> already exists.
```

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          | X         |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |  X        |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
    - This is **required** for new features.

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer, and a fellow student.
- [x] Technical Debt: If temporary workarounds or "TODOs" were used, I have opened a tracking issue to address them properly.
    - Linked Issues: None.
    - The Presenter needed to have at least some kind of state in order to work with already-existing code in `template.ts`. Hence, an `error` member variable was introduced to distinguish success of execution. 
    - The test cases for `createUseCase` can be more robust. For example, we can add tests that verify correctness of the input sanitization.

## Questions and Comments

The changes that I made are quite significant and currently stands out from the rest of the usecases' implementations. I am open to any feedback on this change.