### PR TITLE
Add python, typescript, javascript as file types to the FileStorage datatype in sessionData

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
+Angelina Jiang,
 Anna Myllyniemi,
 Eric Xu,
 Matthew Dahlgren,

--- a/clean-architecture-visualizer/src/types/sessionData.ts
+++ b/clean-architecture-visualizer/src/types/sessionData.ts
@@ -21,7 +21,7 @@ export type SessionData = {
 
 export type FileStorage = {
     filePath: string,
-    fileType: "java" | "not_java",
+    fileType: "java" | "python" | "javascript" | "typescript" | "unknown",
     layer: cleanLayer,
     node: cleanNode
 };

--- a/clean-architecture-visualizer/src/use_case/getFileContent/getFileContentInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/getFileContent/getFileContentInteractor.ts
@@ -24,7 +24,7 @@ export class GetFileContentInteractor implements GetFileContentInputBoundary {
         const result = {
             file_path: filePath,
             content: fileContent,
-            language: fileEntry.fileType ?? "not_java",
+            language: fileEntry.fileType ?? "unknown",
             layer: fileEntry.layer,
             Violation_words: [],
             lines_with_violations: []

--- a/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
@@ -232,13 +232,24 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
  
             result.push({
                 filePath,
-                fileType: filePath.endsWith(".java") ? "java" : "not_java",
+                fileType: this.determineFileType(filePath),
                 layer,
                 node,
             });
         }
  
         return result;
+    }
+
+    /**
+     * Helper function to return the fileType based on the filePath
+     */
+    private determineFileType(filePath: string): "java" | "python" | "javascript" | "typescript" | "unknown" {
+        if (filePath.endsWith(".java")) return "java";
+        if (filePath.endsWith(".py")) return "python";
+        if (filePath.endsWith(".js")) return "javascript";
+        if (filePath.endsWith(".ts") || filePath.endsWith(".tsx")) return "typescript";
+        return "unknown";
     }
 
     private buildNodeStorageList(files: FileStorage[]): NodeStorage[] {

--- a/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
+++ b/clean-architecture-visualizer/src/use_case/graphVerification/graphVerificationInteractor.ts
@@ -8,7 +8,7 @@ import type { EdgeStorage, FileStorage, NodeStorage } from "../../types/sessionD
 import type { cleanLayer } from "../../types/cleanLayer.js";
 import { GraphVerificationOutputData } from "./graphVerificationOutputData.js";
 
-export class GraphVerificationInteractor implements GraphVerificationInputBoundary{
+export class GraphVerificationInteractor implements GraphVerificationInputBoundary {
     private readonly internalDirectories = [
         "use_case",
         "interface_adapter",
@@ -19,13 +19,13 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
         "data_access",
         "database",
     ]
-    
+
     // Paths are defined as <File Name, File Path>
     private readonly internalFilePaths = new Map<string, string>();
     private readonly externalFilePaths = new Map<string, string>();
 
     // The node of files <File Name, Node>
-    private readonly externalNodes : Record<string, cleanNode> = {};
+    private readonly externalNodes: Record<string, cleanNode> = {};
 
     private toCommandLine: boolean = false;
     private outputData: GraphVerificationOutputData;
@@ -87,7 +87,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
      * paths.
      */
     private async developOutNeighbours(): Promise<void> {
-        
+
         for (const graph of this.useCaseGraphList) {
             for (const [fileName, filePath] of graph.getFiles()) {
                 const fromNode = this.resolveNode(filePath);
@@ -224,12 +224,12 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
      */
     private buildFileStorageList(fileMap: Map<string, string>): FileStorage[] {
         const result: FileStorage[] = [];
- 
+
         for (const [, filePath] of fileMap) {
             const node = this.resolveNode(filePath);
             const layer = this.resolveLayer(filePath);
             if (!node || !layer) continue;
- 
+
             result.push({
                 filePath,
                 fileType: this.determineFileType(filePath),
@@ -237,7 +237,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
                 node,
             });
         }
- 
+
         return result;
     }
 
@@ -247,7 +247,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
     private determineFileType(filePath: string): "java" | "python" | "javascript" | "typescript" | "unknown" {
         if (filePath.endsWith(".java")) return "java";
         if (filePath.endsWith(".py")) return "python";
-        if (filePath.endsWith(".js")) return "javascript";
+        if (filePath.endsWith(".js") || filePath.endsWith(".jsx")) return "javascript";
         if (filePath.endsWith(".ts") || filePath.endsWith(".tsx")) return "typescript";
         return "unknown";
     }
@@ -318,20 +318,20 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
     private buildEdgeStorageList(): EdgeStorage[] {
         const result: EdgeStorage[] = [];
         const seenIds = new Set<string>();
- 
+
         for (const uc of this.useCaseGraphList) {
             const violationSet = new Set<string>(
                 uc.getViolationEdges().map(([from, to]) => `${from}->${to}`)
             );
- 
+
             const neighbourMap = uc.getNeighbourMap();
- 
+
             for (const [fromNode, neighbours] of Object.entries(neighbourMap) as [cleanNode, cleanNode[]][]) {
                 for (const toNode of neighbours) {
                     const id = `${fromNode}->${toNode}`;
                     if (seenIds.has(id)) continue;
                     seenIds.add(id);
- 
+
                     result.push({
                         id,
                         source: fromNode,
@@ -342,10 +342,10 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
                 }
             }
         }
- 
+
         return result;
     }
- 
+
     /**
      * Fallback layer resolution by node type, for missing nodes that have no matching file.
      */
@@ -368,7 +368,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
             case "useCaseInteractor":
             case "dataAccessInterface":
                 return "applicationBusinessRules"
-                ;
+                    ;
             case "entities":
                 return "enterpriseBusinessRules";
         }
@@ -377,11 +377,11 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
     private async populateDatabase(): Promise<void> {
         const totalUseCases = this.useCaseGraphList.length;
         let violationCount = 0;
- 
+
         this.useCaseGraphList.forEach(useCase => {
             violationCount += useCase.getViolationCount();
         });
- 
+
         const files: FileStorage[] = [
             ...this.buildFileStorageList(this.internalFilePaths),
             ...this.buildFileStorageList(this.externalFilePaths),
@@ -389,7 +389,7 @@ export class GraphVerificationInteractor implements GraphVerificationInputBounda
 
         const nodes: NodeStorage[] = this.buildNodeStorageList(files);
         const edges: EdgeStorage[] = this.buildEdgeStorageList();
- 
+
         this.db.setNumUseCases(totalUseCases);
         this.db.setNumViolations(violationCount);
         this.db.setUseCases(this.useCaseGraphList, files);

--- a/clean-architecture-visualizer/tests/backend/use_cases/getFileContent.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getFileContent.test.ts
@@ -25,23 +25,47 @@ function makeOutputData(): GetFileContentOutputData & { result: any } {
     };
 }
 
-const mockFile: FileStorage = {
+const mockFile: FileStorage[] = [{
     filePath: "/src/interface_adapters/UserSignupController.java",
     fileType: "java",
     layer: "interfaceAdapters",
     node: "controller",
-};
+}, {
+    filePath: "/src/interface_adapters/UserSignupController.py",
+    fileType: "python",
+    layer: "interfaceAdapters",
+    node: "controller",
+}, {
+    filePath: "/src/interface_adapters/UserSignupController.js",
+    fileType: "javascript",
+    layer: "interfaceAdapters",
+    node: "controller",
+}, {
+    filePath: "/src/interface_adapters/UserSignupController.ts",
+    fileType: "typescript",
+    layer: "interfaceAdapters",
+    node: "controller",
+}, {
+    filePath: "/src/interface_adapters/UserSignupController.tsx",
+    fileType: "typescript",
+    layer: "interfaceAdapters",
+    node: "controller",
+}]
 
 describe("GetFileContentInteractor", () => {
 
     describe("getFileContent — file found in DB", () => {
 
         beforeEach(() => {
-            genericDBAccess.upsertFile(mockFile);
+            for (const file of mockFile) {
+                genericDBAccess.upsertFile(file);
+            }
         });
 
         afterEach(() => {
-            genericDBAccess.removeFile(mockFile.filePath);
+            for (const file of mockFile) {
+                genericDBAccess.removeFile(file.filePath);
+            }
         });
 
         it("sets file_path on the output data", async () => {
@@ -74,24 +98,64 @@ describe("GetFileContentInteractor", () => {
             expect(outputData.result?.language).toBe("java");
         });
 
-        it("sets language to 'not_java' for non-java files", async () => {
-            const tsFile: FileStorage = {
-                filePath: "/src/interface_adapters/UserSignupController.ts",
-                fileType: "not_java",
-                layer: "interfaceAdapters",
-                node: "controller",
-            };
-            genericDBAccess.upsertFile(tsFile);
+        it("sets language to 'python' for python files", async () => {
+            const inputData = makeInputData("/src/interface_adapters/UserSignupController.py");
+            const outputData = makeOutputData();
+            const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
 
+            await interactor.getFileContent();
+
+            expect(outputData.result?.language).toBe("python");
+        });
+
+        it("sets language to 'javascript' for javascript files", async () => {
+            const inputData = makeInputData("/src/interface_adapters/UserSignupController.js");
+            const outputData = makeOutputData();
+            const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
+
+            await interactor.getFileContent();
+
+            expect(outputData.result?.language).toBe("javascript");
+        });
+
+        it("sets language to 'typescript' for typescript files ending with .ts", async () => {
             const inputData = makeInputData("/src/interface_adapters/UserSignupController.ts");
             const outputData = makeOutputData();
             const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
 
             await interactor.getFileContent();
 
-            expect(outputData.result?.language).toBe("not_java");
+            expect(outputData.result?.language).toBe("typescript");
+        });
 
-            genericDBAccess.removeFile(tsFile.filePath);
+        it("sets language to 'typescript' for typescript files ending with .tsx", async () => {
+            const inputData = makeInputData("/src/interface_adapters/UserSignupController.tsx");
+            const outputData = makeOutputData();
+            const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
+
+            await interactor.getFileContent();
+
+            expect(outputData.result?.language).toBe("typescript");
+        });
+
+        it("sets language to 'unknown' for unrecognized file types", async () => {
+            const txtFile: FileStorage = {
+                filePath: "/src/interface_adapters/UserSignupController.txt",
+                fileType: "unknown",
+                layer: "interfaceAdapters",
+                node: "controller",
+            };
+            genericDBAccess.upsertFile(txtFile);
+
+            const inputData = makeInputData("/src/interface_adapters/UserSignupController.txt");
+            const outputData = makeOutputData();
+            const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
+
+            await interactor.getFileContent();
+
+            expect(outputData.result?.language).toBe("unknown");
+
+            genericDBAccess.removeFile(txtFile.filePath);
         });
 
         it("initialises violation fields as empty arrays", async () => {

--- a/clean-architecture-visualizer/tests/backend/use_cases/getFileContent.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getFileContent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach} from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { GetFileContentInteractor } from "../../../src/use_case/getFileContent/getFileContentInteractor.js";
 import { FileAccess } from "../../../src/data_access/fileAccess.js";
 import { SessionDBAccess } from "../../../src/data_access/sessionDBAccess.js";
@@ -37,6 +37,11 @@ const mockFile: FileStorage[] = [{
     node: "controller",
 }, {
     filePath: "/src/interface_adapters/UserSignupController.js",
+    fileType: "javascript",
+    layer: "interfaceAdapters",
+    node: "controller",
+}, {
+    filePath: "/src/interface_adapters/UserSignupController.jsx",
     fileType: "javascript",
     layer: "interfaceAdapters",
     node: "controller",
@@ -108,8 +113,18 @@ describe("GetFileContentInteractor", () => {
             expect(outputData.result?.language).toBe("python");
         });
 
-        it("sets language to 'javascript' for javascript files", async () => {
+        it("sets language to 'javascript' for javascript files ending with .js", async () => {
             const inputData = makeInputData("/src/interface_adapters/UserSignupController.js");
+            const outputData = makeOutputData();
+            const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
+
+            await interactor.getFileContent();
+
+            expect(outputData.result?.language).toBe("javascript");
+        });
+
+        it("sets language to 'javascript' for javascript files ending with .jsx", async () => {
+            const inputData = makeInputData("/src/interface_adapters/UserSignupController.jsx");
             const outputData = makeOutputData();
             const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
 
@@ -146,15 +161,11 @@ describe("GetFileContentInteractor", () => {
                 node: "controller",
             };
             genericDBAccess.upsertFile(txtFile);
-
             const inputData = makeInputData("/src/interface_adapters/UserSignupController.txt");
             const outputData = makeOutputData();
             const interactor = new GetFileContentInteractor(genericDBAccess, genericFileAccess, inputData, outputData);
-
             await interactor.getFileContent();
-
             expect(outputData.result?.language).toBe("unknown");
-
             genericDBAccess.removeFile(txtFile.filePath);
         });
 

--- a/clean-architecture-visualizer/tests/backend/use_cases/getRelations.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getRelations.test.ts
@@ -112,8 +112,8 @@ describe("GetRelationsInteractor", () => {
             const targetPath = "src/entities/User.ts";
             const tsReferrer = "src/controller/UserController.ts";
 
-            genericDBAccess.upsertFile({ filePath: targetPath, fileType: "not_java", layer: "entities", node: "node" });
-            genericDBAccess.upsertFile({ filePath: tsReferrer, fileType: "not_java", layer: "interfaceAdapters", node: "node" });
+            genericDBAccess.upsertFile({ filePath: targetPath, fileType: "typescript", layer: "entities", node: "node" });
+            genericDBAccess.upsertFile({ filePath: tsReferrer, fileType: "typescript", layer: "interfaceAdapters", node: "node" });
 
             // Mock getFileImports to return a match for "User"
             jest.spyOn(genericFileAccess, 'getFileImports').mockResolvedValue([

--- a/docs/developers/Session-Database.md
+++ b/docs/developers/Session-Database.md
@@ -56,7 +56,7 @@ Represents a single scanned file:
 | Field | Type | Description |
 |---|---|---|
 | `filePath` | `string` | Absolute path to the file |
-| `fileType` | `"java" \| "not_java"` | Whether the file is a Java source file |
+| `fileType` | `"java" \| "python" \| "javascript" \| "typescript" \| "unknown"` | The programming language of the source file |
 | `layer` | `cleanLayer` | Which clean architecture layer it belongs to |
 | `node` | `cleanNode` | The node type it represents |
 


### PR DESCRIPTION
## Overview
This PR changes `.fileType` of `FileStorage` datatype in `src\types\sessionData.ts` and updates test cases in `tests\backend\use_cases`. Currently, it is either of type `"java" | "not_java"`. These changes were made so that if a student ever uses an API that requires other languages, such as Python, Typescript, or Javascript, then the frontend can properly format the code. Now, `.fileType` can be: "java", "typescript", "javascript, "python", "unknown". 

## Proposed Changes

This addresses #143. 

The change involves updating the `FileStorage` datatype in `src\types\sessionData.ts`, changing all instances of `"not_java" to "unknown".

A helper function (`determineFileType()`) in `src\use_case\graphVerification\graphVerificationInteractor.ts` is created to return the fileType as a string, given its filePath. It's used in the function `buildFileStorageList()`. 

New test cases in `tests\backend\use_cases\getFileContent.test.ts` are added to account for if the source file is a python, javascript, or typescript file. Furthermore, the not_java testcase previously used a `.ts` file, which was replaced with a `.txt` file instead. The mock data was stored inside an array, instead of creating 4 individual files for each programming language. 

Since this changes what is being stored in the database, `docs\developers\Session-Database.md` is updated. 

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## How to Test & Review

I ran `npm test` and `npm run build` to determine whether or not the code still ran. 

All testing files that have been changed passed the `npm test` (albeit some files did not pass the npm test, not sure if it's because of a Unix vs Windows difference, regarding the path separator being `\` or `/`). I decided that the files that failed did not fail because of the changes made in the FileStorage datatype. 

`npm run build` ran without any issues. 

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |     X    |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |     X    |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |      X   |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [X] I have updated the project documentation, if applicable.
    - This is **required** for new features.
- [ ] **(Frontend)** I have added/updated text in `i18n` JSON files for any new user-facing strings to support multilingual features.
After opening your pull request:

- [X] I have verified that the CI tests have passed.
- [X] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer, and a fellow student.
- [ ] Technical Debt: If temporary workarounds or "TODOs" were used, I have opened a tracking issue to address them properly.
    - Linked Issues: 

## Questions and Comments

In `tests\backend\use_cases\getRelations.test.ts`, I did not split the Non-Java Relation Detection test suite into multiple suites because of how `src\use_case\getRelations\GetRelationsInteractor.ts` is implemented, such that it does not account if the type of the source file is not Java, grouping together the Typescript, Javascript, Python, and "Unknown". I'm not sure if I should have made multiple test cases within the test suite, as there is currently only one testing for Typescript as the "non-java" file. 