### PR TITLE
fix(test): backend use case test typescript fixes

### DIFF
--- a/clean-architecture-visualizer/tests/backend/database/sessiondb.test.ts
+++ b/clean-architecture-visualizer/tests/backend/database/sessiondb.test.ts
@@ -71,12 +71,20 @@ describe("SessionDB", () => {
         });
 
         it("restores nested data correctly", () => {
-            db.set("files", { "User.java": "src/entities/User.java" });
+            const files: SessionData["files"] = [
+                {
+                    filePath: "src/entities/User.java",
+                    fileType: "java",
+                    layer: "enterpriseBusinessRules",
+                    node: "entities",
+                },
+            ];
+            db.set("files", files);
 
             const db2 = new SessionDB<SessionData>();
             db2.load();
 
-            expect(db2.get("files")).toEqual({ "User.java": "src/entities/User.java" });
+            expect(db2.get("files")).toEqual(files);
         });
     });
 

--- a/clean-architecture-visualizer/tests/backend/use_cases/getFileTree.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getFileTree.test.ts
@@ -2,18 +2,20 @@ import { describe, it, expect, beforeEach} from '@jest/globals';
 
 import { GetFileTreeInteractor } from "../../../src/use_case/getFileTree/getFileTreeInteractor.js";
 import { SessionDBAccess } from "../../../src/data_access/sessionDBAccess.js";
-import type { GetFileTreeOutputData } from "../../../src/use_case/getFileTree/getFileTreeOuptutData.js";
+import { GetFileTreeOutputData } from "../../../src/use_case/getFileTree/getFileTreeOuptutData.js";
 import type { FileStorage } from "../../../src/types/sessionData.js";
 import type { FileTreeNode } from "../../../src/types/fileTreeNode.js";
 
 let genericDBAccess = new SessionDBAccess();
 
-// mock for output data
 function makeOutputData(): GetFileTreeOutputData & { result: FileTreeNode | undefined } {
-    return {
-        result: undefined,
-        setOutputData(data: FileTreeNode) { this.result = data; }
-    };
+    const output = new GetFileTreeOutputData();
+    Object.defineProperty(output, "result", {
+        get(): FileTreeNode | undefined {
+            return output.getOutputData() as FileTreeNode;
+        },
+    });
+    return output as GetFileTreeOutputData & { result: FileTreeNode | undefined };
 }
 
 describe("GetFileTreeInteractor", () => {
@@ -38,8 +40,8 @@ describe("GetFileTreeInteractor", () => {
             const mockFile: FileStorage = {
                 filePath: "project/src/entities/User.java",
                 fileType: "java",
-                layer: "entities",
-                node: "UserNode",
+                layer: "enterpriseBusinessRules",
+                node: "entities",
             };
             genericDBAccess.upsertFile(mockFile);
 
@@ -61,8 +63,18 @@ describe("GetFileTreeInteractor", () => {
         });
 
         it("shares the same directory node for multiple files in that directory", async () => {
-            const file1: FileStorage = { filePath: "src/util/A.java", fileType: "java", layer: "entities", node: "A" };
-            const file2: FileStorage = { filePath: "src/util/B.java", fileType: "java", layer: "entities", node: "B" };
+            const file1: FileStorage = {
+                filePath: "src/util/A.java",
+                fileType: "java",
+                layer: "enterpriseBusinessRules",
+                node: "entities",
+            };
+            const file2: FileStorage = {
+                filePath: "src/util/B.java",
+                fileType: "java",
+                layer: "enterpriseBusinessRules",
+                node: "entities",
+            };
             
             genericDBAccess.upsertFile(file1);
             genericDBAccess.upsertFile(file2);

--- a/clean-architecture-visualizer/tests/backend/use_cases/getLearningMode.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getLearningMode.test.ts
@@ -2,16 +2,18 @@ import { describe, it, expect} from '@jest/globals';
 
 import { GetLearningModeInteractor } from "../../../src/use_case/getLearningMode/getLearningModeInteractor.js";
 import { CleanArchAccess } from "../../../src/data_access/cleanArchInfoAccess.js";
-import type { GetLearningModeOutputData } from "../../../src/use_case/getLearningMode/getLearningModeOutputData.js";
+import { GetLearningModeOutputData } from "../../../src/use_case/getLearningMode/getLearningModeOutputData.js";
 
 const genericCleanArchAccess = new CleanArchAccess();
 
-// Minimal mock for output data
 function makeOutputData(): GetLearningModeOutputData & { result: any } {
-    return {
-        result: undefined,
-        setOutputData(data: any) { this.result = data; }
-    };
+    const output = new GetLearningModeOutputData();
+    Object.defineProperty(output, "result", {
+        get(): any {
+            return output.getOutputData();
+        },
+    });
+    return output as GetLearningModeOutputData & { result: any };
 }
 
 describe("GetLearningModeInteractor", () => {

--- a/clean-architecture-visualizer/tests/backend/use_cases/getRelations.test.ts
+++ b/clean-architecture-visualizer/tests/backend/use_cases/getRelations.test.ts
@@ -2,7 +2,7 @@ import { GetRelationsInteractor } from "../../../src/use_case/getRelations/GetRe
 import { SessionDBAccess } from "../../../src/data_access/sessionDBAccess.js";
 import { FileAccess } from "../../../src/data_access/fileAccess.js";
 import type { GetRelationsInputData } from "../../../src/use_case/getRelations/GetRelationsInputData.js";
-import type { GetRelationsOutputData } from "../../../src/use_case/getRelations/GetRelationsOutputData.js";
+import { GetRelationsOutputData } from "../../../src/use_case/getRelations/GetRelationsOutputData.js";
 
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
@@ -16,11 +16,13 @@ function makeInputData(filePath: string): GetRelationsInputData {
 }
 
 function makeOutputData(): GetRelationsOutputData & { result: any } {
-    return {
-        result: undefined,
-        setOutputData(data: any) { this.result = data; },
-        getOutputData() { return this.result; }
-    } as GetRelationsOutputData & { result: any };
+    const output = new GetRelationsOutputData();
+    Object.defineProperty(output, "result", {
+        get(): any {
+            return output.getOutputData();
+        },
+    });
+    return output as GetRelationsOutputData & { result: any };
 }
 
 describe("GetRelationsInteractor", () => {
@@ -112,8 +114,18 @@ describe("GetRelationsInteractor", () => {
             const targetPath = "src/entities/User.ts";
             const tsReferrer = "src/controller/UserController.ts";
 
-            genericDBAccess.upsertFile({ filePath: targetPath, fileType: "not_java", layer: "entities", node: "node" });
-            genericDBAccess.upsertFile({ filePath: tsReferrer, fileType: "not_java", layer: "interfaceAdapters", node: "node" });
+            genericDBAccess.upsertFile({
+                filePath: targetPath,
+                fileType: "not_java",
+                layer: "enterpriseBusinessRules",
+                node: "entities",
+            });
+            genericDBAccess.upsertFile({
+                filePath: tsReferrer,
+                fileType: "not_java",
+                layer: "interfaceAdapters",
+                node: "controller",
+            });
 
             // Mock getFileImports to return a match for "User"
             jest.spyOn(genericFileAccess, 'getFileImports').mockResolvedValue([
@@ -138,7 +150,12 @@ describe("GetRelationsInteractor", () => {
 
         it("ignores the target file itself even if it contains its own name", async () => {
             const path = "src/entities/User.java";
-            genericDBAccess.upsertFile({ filePath: path, fileType: "java", layer: "entities", node: "node" });
+            genericDBAccess.upsertFile({
+                filePath: path,
+                fileType: "java",
+                layer: "enterpriseBusinessRules",
+                node: "entities",
+            });
             
             jest.spyOn(genericFileAccess, 'getFileContent').mockResolvedValue("public class User { User() {} }");
 


### PR DESCRIPTION

- Fixed TypeScript errors in backend use case tests for `getFileTree`, `getLearningMode`, and `getRelations`.
- Use valid `cleanLayer` and `cleanNode` values on `FileStorage` test data.