### PR TITLE
feat: add global NavBar and AppLayout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 *.tsbuildinfo
 clean-architecture-visualizer/frontend/public/
 
+# IDE
+.idea/
+
 # Secrets
 .DS_Store
 .env

--- a/clean-architecture-visualizer/frontend/package-lock.json
+++ b/clean-architecture-visualizer/frontend/package-lock.json
@@ -149,6 +149,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -528,6 +529,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -576,6 +578,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -638,6 +641,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -681,6 +685,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1664,6 +1669,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.8.tgz",
       "integrity": "sha512-QKd1RhDXE1hf2sQDNayA9ic9jGkEgvZOf0tTkJxlBPG8ns8aS4rS8WwYURw2x5y3739p0HauUXX9WbH7UufFLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.8",
@@ -2698,7 +2704,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2708,8 +2713,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -2778,8 +2782,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3123,6 +3126,7 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3144,6 +3148,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3155,6 +3160,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3179,8 +3185,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -3217,6 +3222,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3572,6 +3578,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3755,6 +3762,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4087,6 +4095,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4195,7 +4204,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4222,7 +4230,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -4408,6 +4415,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5057,6 +5065,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -5401,7 +5410,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5421,7 +5429,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5515,6 +5522,7 @@
       "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -5897,7 +5905,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5913,7 +5920,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5926,8 +5932,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5967,6 +5972,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5979,6 +5985,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6176,6 +6183,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6613,6 +6621,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6727,6 +6736,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7098,6 +7108,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/clean-architecture-visualizer/frontend/src/App.tsx
+++ b/clean-architecture-visualizer/frontend/src/App.tsx
@@ -6,9 +6,11 @@ import CheckerMode from './pages/CheckerMode';
 import ProjectStarter from './pages/ProjectStarter';
 import UseCaseInteractionDiagram from './pages/UseCaseInteractionDiagram';
 import UseCaseInteractionCode from './pages/UseCaseInteractionCode';
+import TestYourself from './pages/TestYourself';
+import AppLayout from './layouts/AppLayout';
 import { ThemeProvider } from '@mui/material/styles';
 import { lightTheme } from './lib';
-
+import './i18n/config';
 
 export default function App() {
     return (
@@ -17,12 +19,15 @@ export default function App() {
             <AppGlobalStyles />
         <Router>
                 <Routes>
-                    <Route path='/' element={<Home />} />
-                    <Route path='/learning' element={<LearningMode />} />
-                    <Route path='/checker' element={<CheckerMode />} />
-                    <Route path='/project-starter' element={<ProjectStarter />} />
-                    <Route path='/use-case/:useCaseId/interaction/:interactionId/diagram' element={<UseCaseInteractionDiagram />} />
-                    <Route path='/use-case/:useCaseId/interaction/:interactionId/code' element={<UseCaseInteractionCode />} />
+                    <Route element={<AppLayout />}>
+                        <Route path='/' element={<Home />} />
+                        <Route path='/learning' element={<LearningMode />} />
+                        <Route path='/test-yourself' element={<TestYourself />} />
+                        <Route path='/checker' element={<CheckerMode />} />
+                        <Route path='/project-starter' element={<ProjectStarter />} />
+                        <Route path='/use-case/:useCaseId/interaction/:interactionId/diagram' element={<UseCaseInteractionDiagram />} />
+                        <Route path='/use-case/:useCaseId/interaction/:interactionId/code' element={<UseCaseInteractionCode />} />
+                    </Route>
                 </Routes>
             </Router>
         </ThemeProvider>

--- a/clean-architecture-visualizer/frontend/src/components/common/Header.tsx
+++ b/clean-architecture-visualizer/frontend/src/components/common/Header.tsx
@@ -1,9 +1,8 @@
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { ReactNode } from 'react';
 import Dropdown, { DropdownOption } from './Dropdown.tsx';
-import { Box, Paper, Typography } from '@mui/material';
-import { HomeIcon } from '../../assets/icons';
+import { Box, Paper } from '@mui/material';
 import { useAnalysisSummary } from '../../actions/useAnalysis.ts';
 import { Interaction, UseCase } from '../../lib/types.ts';
 
@@ -59,31 +58,21 @@ export default function Header({ actions }: HeaderProps) {
                         justifyContent: 'space-between',
                         minHeight: 77, // Ensure consistent height even if actions are empty
                         p: 2,
-                        gap: 0,
+                        gap: 2,
                     }}
                 >
-                    {/* Home Link */}
-                    <Box component={Link} to="/" sx={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center' }}>
-                        <Box sx={{ width: 32, height: 32, display: 'inline-flex', alignItems: 'center'}}>
-                            <HomeIcon style={{ width: '100%', height: '100%', verticalAlign: 'middle' }} />
-                        </Box>
-                        <Typography variant="h6" component="span" sx={{ marginLeft: 1, color: 'text.primary' }}>
-                            {t('branding.name')}
-                        </Typography>
-                    </Box>
-
                     <Box
                         sx={{
                             display: 'flex',
                             alignItems: 'center',
                             gap: 1,
-                            flexWrap: 'wrap',
+                            flexShrink: 0,
                         }}
                     >
                         {actions}
                     </Box>
 
-                    <Box>
+                    <Box sx={{ flexShrink: 0 }}>
                         <Dropdown options={navigationOptions} onSelect={handleNavigation} />
                     </Box>
                 </Box>

--- a/clean-architecture-visualizer/frontend/src/components/common/NavBar.tsx
+++ b/clean-architecture-visualizer/frontend/src/components/common/NavBar.tsx
@@ -1,0 +1,166 @@
+import { Link, NavLink, useLocation } from 'react-router-dom';
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import CaveLogo from '../../assets/locales/logo_dark.svg';
+
+export const NAV_BAR_HEIGHT = 64;
+const LOGO_SIZE = 36;
+const LOGO_GROUP_WIDTH = 180;
+const NAV_ITEM_MIN_WIDTH = 100;
+const NAV_ITEM_HEIGHT = 40;
+
+const NAV_ITEMS = [
+    { to: '/', labelKey: 'navBar.home', end: true as const },
+    { to: '/learning', labelKey: 'navBar.diagram', matchDiagram: true },
+    { to: '/test-yourself', labelKey: 'navBar.testYourself' },
+] as const;
+
+function isNavItemActive(
+    to: string,
+    matchDiagram: boolean | undefined,
+    pathname: string,
+    navIsActive: boolean,
+): boolean {
+    if (to === '/') {
+        return navIsActive;
+    }
+    if (matchDiagram) {
+        return navIsActive || pathname.includes('/diagram');
+    }
+    return navIsActive;
+}
+
+export default function NavBar() {
+    const { t } = useTranslation('common');
+    const { pathname } = useLocation();
+
+    return (
+        <Box
+            component="nav"
+            aria-label={t('navBar.ariaLabel')}
+            sx={{
+                flexShrink: 0,
+                height: NAV_BAR_HEIGHT,
+                bgcolor: 'background.paper',
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                gap: 3,
+                px: 3,
+            }}
+        >
+            <Box
+                component={Link}
+                to="/"
+                aria-label={t('navBar.home')}
+                sx={{
+                    flexShrink: 0,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    width: LOGO_GROUP_WIDTH,
+                    minWidth: LOGO_GROUP_WIDTH,
+                    textDecoration: 'none',
+                }}
+            >
+                <Box
+                    component="img"
+                    src={CaveLogo}
+                    alt=""
+                    sx={{
+                        width: LOGO_SIZE,
+                        height: LOGO_SIZE,
+                        minWidth: LOGO_SIZE,
+                        minHeight: LOGO_SIZE,
+                        flexShrink: 0,
+                    }}
+                />
+                <Typography
+                    component="span"
+                    sx={{
+                        flexShrink: 0,
+                        fontWeight: 800,
+                        fontSize: 20,
+                        lineHeight: 1,
+                        color: 'text.primary',
+                        letterSpacing: '0.02em',
+                    }}
+                >
+                    {t('branding.name')}
+                </Typography>
+                <Box
+                    component="span"
+                    sx={{
+                        flexShrink: 0,
+                        bgcolor: 'useCases.main',
+                        color: '#fff',
+                        fontSize: 10,
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        px: 0.75,
+                        py: 0.25,
+                        borderRadius: '4px',
+                        letterSpacing: '0.06em',
+                    }}
+                >
+                    {t('navBar.learnBadge')}
+                </Box>
+            </Box>
+
+            <Box
+                sx={{
+                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    gap: 1,
+                }}
+            >
+                {NAV_ITEMS.map(({ to, labelKey, ...item }) => (
+                    <NavLink
+                        key={to}
+                        to={to}
+                        end={'end' in item ? item.end : false}
+                        style={{ textDecoration: 'none', flexShrink: 0 }}
+                    >
+                        {({ isActive: navIsActive }) => {
+                            const isActive = isNavItemActive(
+                                to,
+                                'matchDiagram' in item ? item.matchDiagram : false,
+                                pathname,
+                                navIsActive,
+                            );
+
+                            return (
+                                <Box
+                                    component="span"
+                                    sx={{
+                                        flexShrink: 0,
+                                        minWidth: NAV_ITEM_MIN_WIDTH,
+                                        width: NAV_ITEM_MIN_WIDTH,
+                                        height: NAV_ITEM_HEIGHT,
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        px: 2.5,
+                                        borderRadius: '999px',
+                                        fontSize: 15,
+                                        fontWeight: 500,
+                                        lineHeight: 1,
+                                        color: isActive ? 'text.primary' : 'text.secondary',
+                                        bgcolor: isActive ? '#f5f1ea' : 'transparent',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {t(labelKey)}
+                                </Box>
+                            );
+                        }}
+                    </NavLink>
+                ))}
+            </Box>
+        </Box>
+    );
+}

--- a/clean-architecture-visualizer/frontend/src/components/diagram/CADiagramPageLayout.ts
+++ b/clean-architecture-visualizer/frontend/src/components/diagram/CADiagramPageLayout.ts
@@ -4,7 +4,9 @@ import { Box } from '@mui/material';
 export const PageContainer = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
-  height: '100vh',
+  flex: 1,
+  minHeight: 0,
+  height: '100%',
   overflow: 'hidden',
 });
 

--- a/clean-architecture-visualizer/frontend/src/i18n/locales/en/common.json
+++ b/clean-architecture-visualizer/frontend/src/i18n/locales/en/common.json
@@ -2,6 +2,17 @@
   "branding": {
     "name": "CAVE"
   },
+  "navBar": {
+    "ariaLabel": "Main navigation",
+    "home": "Home",
+    "diagram": "Diagram",
+    "testYourself": "Test Yourself",
+    "learnBadge": "LEARN"
+  },
+  "testYourselfPage": {
+    "title": "Test Yourself",
+    "description": "This page is a placeholder. Content coming soon."
+  },
   "navigation": {
     "pages": {
       "home": "Home",

--- a/clean-architecture-visualizer/frontend/src/layouts/AppLayout.tsx
+++ b/clean-architecture-visualizer/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,23 @@
+import { Outlet } from 'react-router-dom';
+import { Box } from '@mui/material';
+import NavBar from '../components/common/NavBar';
+
+export default function AppLayout() {
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+            <NavBar />
+            <Box
+                component="main"
+                sx={{
+                    flex: 1,
+                    minHeight: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    bgcolor: '#f5f1ea',
+                }}
+            >
+                <Outlet />
+            </Box>
+        </Box>
+    );
+}

--- a/clean-architecture-visualizer/frontend/src/pages/TestYourself.tsx
+++ b/clean-architecture-visualizer/frontend/src/pages/TestYourself.tsx
@@ -1,0 +1,19 @@
+import { Box, Container, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+export default function TestYourself() {
+    const { t } = useTranslation('common');
+
+    return (
+        <Container maxWidth="md" sx={{ py: 8 }}>
+            <Box sx={{ bgcolor: 'background.paper', borderRadius: 2, p: 4 }}>
+                <Typography variant="h4" component="h1" fontWeight={700} gutterBottom>
+                    {t('testYourselfPage.title')}
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                    {t('testYourselfPage.description')}
+                </Typography>
+            </Box>
+        </Container>
+    );
+}


### PR DESCRIPTION
- Add a shared `NavBar` with Home, Learning/Diagram, and Test Yourself routes,included i18n labels.
- Implement `AppLayout` so the nav appears across app pages; simplify `Header` and wire routes in `App.tsx`.
- Add a placeholder `TestYourself` page and nav copy in `common.json`.
